### PR TITLE
Add item properties

### DIFF
--- a/src/classes/item.rb
+++ b/src/classes/item.rb
@@ -1,0 +1,3 @@
+class Item
+  def initialize; end
+end

--- a/src/classes/item.rb
+++ b/src/classes/item.rb
@@ -1,3 +1,9 @@
 class Item
-  def initialize; end
+  attr_reader :genre, :author, :label, :source
+
+  def initialize(publish_date, id = Random.rand(1..10_000), archived: false)
+    @id = id
+    @publish_date = publish_date
+    @archived = archived
+  end
 end


### PR DESCRIPTION
- All Item class properties visible in the diagram should be defined and set up in the constructor method. Exception: properties for the 1-to-many relationships should NOT be set in the constructor method. Instead, they should have a custom setter method created.